### PR TITLE
Admin analytics

### DIFF
--- a/app/admin/analytics/actions.ts
+++ b/app/admin/analytics/actions.ts
@@ -1,12 +1,13 @@
 "use server";
 
 import prisma from "@/lib/prisma";
-import { Order, OrderItem, Product } from "@prisma/client";
+import { Order } from "@prisma/client";
 
 export interface Activity {
   activeUsers: number;
   activeOrders: number;
 }
+// Gets number of active users (users who placed orders in last 30 days) and number of orders in last 30 days
 export async function getActivity(): Promise<Activity> {
   const activeOrders = await prisma.order.findMany({
     where: {
@@ -26,6 +27,7 @@ export interface RecentOrder {
   order: Order;
   totalWeight: number;
 }
+// Gets orders from last 7 days and their total weight
 export async function getRecentOrders(): Promise<RecentOrder[]> {
   const orders = await prisma.order.findMany({
     where: {
@@ -56,7 +58,7 @@ export interface PopularProductData {
   quantity: number;
   frequency: number;
 }
-
+// Gets the 5 most popular products from orders in the last 30 days, along with the quantities sold and frequency seen in orders as a percentage
 export async function getPopularProducts(): Promise<PopularProductData[]> {
   // Get orders from last 30 days
   const recentOrderIds = (

--- a/app/admin/analytics/components/orders-table.tsx
+++ b/app/admin/analytics/components/orders-table.tsx
@@ -1,4 +1,4 @@
-import { $Enums, Prisma } from "@prisma/client";
+import { $Enums } from "@prisma/client";
 import { ReactNode } from "react";
 import {
   Table,
@@ -24,8 +24,6 @@ interface OrdersTableProps {
 }
 
 export function OrdersTable({ orderList }: OrdersTableProps): ReactNode {
-  const limitedData = orderList.slice(0, 8);
-
   function getStatusColor(status: string): string {
     switch (status) {
       case "PENDING":
@@ -41,6 +39,7 @@ export function OrdersTable({ orderList }: OrdersTableProps): ReactNode {
 
   return (
     <div className="overflow-x-auto">
+      {/* Scrollable table */}
       <ScrollArea className="h-60">
         <Table>
           <TableHeader>

--- a/app/admin/analytics/components/product-pie-chart.tsx
+++ b/app/admin/analytics/components/product-pie-chart.tsx
@@ -1,14 +1,5 @@
 "use client";
-import { TrendingUp } from "lucide-react";
 import { Pie, PieChart } from "recharts";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import {
   ChartConfig,
   ChartContainer,
@@ -23,7 +14,8 @@ type PieChartProductsProps = {
 };
 
 export function PieChartProducts(data: PieChartProductsProps) {
-  const chartColors = ["#e16704", "#d6395b", "#993f84", "#464882", "#013f5c"];
+  // https://ui.shadcn.com/charts/pie#charts
+  const chartColors = ["#e16704", "#d6395b", "#993f84", "#464882", "#013f5c"]; // https://www.learnui.design/tools/data-color-picker.html
   const chartData = [];
   for (const [index, element] of data.popularProductData.entries()) {
     if (index >= 5) break; // This should not execute due to actions.ts only selecting 5 elements max
@@ -39,8 +31,8 @@ export function PieChartProducts(data: PieChartProductsProps) {
     },
     product1: {
       label: chartData[0].name,
-      color: chartColors[0],
-    },
+      color: chartColors[0], // tbh I'm not entirely sure what this does; I'm pretty sure the fill in chartData is all that matters
+    }, // https://ui.shadcn.com/docs/components/chart#chart-config
     product2: {
       label: chartData[1].name,
       color: chartColors[1],

--- a/app/admin/analytics/components/section-cards.tsx
+++ b/app/admin/analytics/components/section-cards.tsx
@@ -1,7 +1,5 @@
 "use server";
 
-import { TrendingDownIcon, TrendingUpIcon } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import {
   Card,
   CardContent,
@@ -25,6 +23,7 @@ type SectionCardsProps = {
 export async function SectionCards(data: SectionCardsProps) {
   return (
     <div className="*:data-[slot=card]:shadow-xs @xl/main:grid-cols-2 @5xl/main:grid-cols-3 grid grid-cols-1 gap-10 px-4 *:data-[slot=card]:bg-gradient-to-t *:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card dark:*:data-[slot=card]:bg-card lg:px-6">
+      {/* Active Users Card */}
       <Card className="@container/card">
         <CardHeader className="relative">
           <CardDescription>Active Users</CardDescription>
@@ -39,6 +38,8 @@ export async function SectionCards(data: SectionCardsProps) {
           <div className="text-muted-foreground">Users in the last 30 days</div>
         </CardFooter>
       </Card>
+
+      {/* Recent Orders Card */}
       <Card className="@container/card">
         <CardHeader className="relative">
           <CardDescription>Recent Orders</CardDescription>
@@ -61,6 +62,8 @@ export async function SectionCards(data: SectionCardsProps) {
           <div className="text-muted-foreground">Orders in the last 7 days</div>
         </CardFooter>
       </Card>
+
+      {/* Popular Product Pie Chart Card */}
       <Card className="@container/card">
         <CardHeader className="relative">
           <CardDescription>Most Popular Product:</CardDescription>

--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -13,10 +13,11 @@ export default async function AdminAnalytics() {
   return (
     <div className="">
       <div className="container mx-auto py-10">
+        {/* Header */}
         <div className="flex justify-between items-center mb-6">
           <h1 className="text-3xl font-bold">Analytics</h1>
-          {/* <AddEmployeeButton /> */}
         </div>
+        {/* Setup for section cards; from shadcn example https://v3.shadcn.com/blocks */}
         <div className="flex flex-1 flex-col">
           <div className="@container/main flex flex-1 flex-col gap-2">
             <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">


### PR DESCRIPTION
Solves #49
Created basic admin analytics page

## Functionality:
- **Shows the number of "active users"** and the number of **placed orders**
  - "Active users" defined by users who placed orders in the last 30 days, as database doesn't contain actual browsing data
  - On second thought, you could maybe try and access the auth table... although that seems pretty unsafe
- Scrollable **table of recent orders** within the last 7 days
  - Shows order status; pending, completed, in-transit
- **Pie chart** showing 5 **most popular products**
  - Gives the percentage of orders that the most popular product appeared in as well (this was actually quite annoying)

## References:
- Grid layout: [shadcn examples](https://v3.shadcn.com/blocks)
- Pie chart: [shadcn pie charts](https://ui.shadcn.com/charts/pie#charts)